### PR TITLE
Leap year

### DIFF
--- a/leap-year.clj
+++ b/leap-year.clj
@@ -1,0 +1,8 @@
+(ns exercises.leap-year)
+
+(defn leap-year?
+  [year]
+  (cond (zero? (mod year 400)) true
+        (zero? (mod year 100)) false
+        (zero? (mod year 4)) true
+        :else false))

--- a/leap-year.clj
+++ b/leap-year.clj
@@ -2,7 +2,8 @@
 
 (defn leap-year?
   [year]
-  (cond (zero? (mod year 400)) true
-        (zero? (mod year 100)) false
-        (zero? (mod year 4)) true
-        :else false))
+  (cond 
+    (-> year (mod 400) zero?) true
+    (-> year (mod 100) zero?) false
+    (-> year (mod 4) zero?) true
+    :else false))


### PR DESCRIPTION
Given a year, report if it is a leap year.

The tricky thing here is that a leap year in the Gregorian calendar occurs:

on every year that is evenly divisible by 4

except every year that is evenly divisible by 100

unless the year is also evenly divisible by 400

For example, 1997 is not a leap year, but 1996 is. 1900 is not a leap year, but 2000 is.